### PR TITLE
Fix gsvd 1x1

### DIFF
--- a/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
+++ b/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
@@ -158,10 +158,6 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
             rocblas_int ldw = m - 1;
             rocblas_int blocks = (m - 2) / BS + 1;
 
-            // set A(0,0) = 1
-            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1, batch_count, 1), dim3(1, 1, 1), 0,
-                               stream, A, strideA, 1, 1);
-
             // copy
             hipLaunchKernelGGL(copyshift_right<T>, dim3(blocks, blocks, batch_count), dim3(BS, BS), 0,
                                stream, true, m - 1, A, shiftA, lda, strideA, work, 0, ldw, strideW);
@@ -194,10 +190,6 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
             rocblas_stride strideW = rocblas_stride(n - 1) * n / 2; // number of elements to copy
             rocblas_int ldw = n - 1;
             rocblas_int blocks = (n - 2) / BS + 1;
-
-            // set A(0,0) = 1
-            hipLaunchKernelGGL(reset_batch_info<T>, dim3(1, batch_count, 1), dim3(1, 1, 1), 0,
-                               stream, A, strideA, 1, 1);
 
             // copy
             hipLaunchKernelGGL(copyshift_down<T>, dim3(blocks, blocks, batch_count), dim3(BS, BS), 0,

--- a/rocsolver/library/src/include/common_device_helpers.hpp
+++ b/rocsolver/library/src/include/common_device_helpers.hpp
@@ -289,7 +289,7 @@ __global__ void copyshift_right(const bool copy,
     T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
 
     // make first row the identity
-    if(i == 0 && j == 0)
+    if(i == 0 && j == 0 && !copy)
         Ap[0] = 1.0;
 
     if(i < dim && j < dim && j <= i)
@@ -333,7 +333,7 @@ __global__ void copyshift_left(const bool copy,
     T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
 
     // make last row the identity
-    if(i == 0 && j == 0)
+    if(i == 0 && j == 0 && !copy)
         Ap[dim + dim * lda] = 1.0;
 
     if(i < dim && j < dim && i <= j)
@@ -378,7 +378,7 @@ __global__ void copyshift_down(const bool copy,
     T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
                 
     // make first column the identity
-    if(i == 0 && j == 0)
+    if(i == 0 && j == 0 && !copy)
         Ap[0] = 1.0;
     
     if(i < dim && j < dim && i <= j)

--- a/rocsolver/library/src/include/common_device_helpers.hpp
+++ b/rocsolver/library/src/include/common_device_helpers.hpp
@@ -285,12 +285,16 @@ __global__ void copyshift_right(const bool copy,
     const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
     const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
+    T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+    T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
+
+    // make first row the identity
+    if(i == 0 && j == 0)
+        Ap[0] = 1.0;
+
     if(i < dim && j < dim && j <= i)
     {
         rocblas_int offset = j * (j + 1) / 2; // to acommodate in smaller array W
-
-        T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
-        T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
 
         if(copy)
         {
@@ -304,11 +308,7 @@ __global__ void copyshift_right(const bool copy,
 
             // make first row the identity
             if(i == j)
-            {
                 Ap[(j + 1) * lda] = 0.0;
-                if(i == 0)
-                    Ap[0] = 1.0;
-            }
         }
     }
 }
@@ -329,12 +329,17 @@ __global__ void copyshift_left(const bool copy,
     const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
     const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
+    T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+    T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
+
+    // make last row the identity
+    if(i == 0 && j == 0)
+        Ap[dim + dim * lda] = 1.0;
+
     if(i < dim && j < dim && i <= j)
     {
         rocblas_int offset = j * ldw - j * (j + 1) / 2; // to acommodate in smaller array W
 
-        T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
-        T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
 
         if(copy)
         {
@@ -348,11 +353,7 @@ __global__ void copyshift_left(const bool copy,
 
             // make last row the identity
             if(i == j)
-            {
                 Ap[dim + j * lda] = 0.0;
-                if(i == 0)
-                    Ap[dim + dim * lda] = 1.0;
-            }
         }
     }
 }
@@ -373,12 +374,16 @@ __global__ void copyshift_down(const bool copy,
     const auto j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
     const auto i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
 
+    T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+    T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
+                
+    // make first column the identity
+    if(i == 0 && j == 0)
+        Ap[0] = 1.0;
+    
     if(i < dim && j < dim && i <= j)
     {
         rocblas_int offset = j * ldw - j * (j + 1) / 2; // to acommodate in smaller array W
-
-        T* Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
-        T* Wp = load_ptr_batch<T>(W, b, shiftW, strideW);
 
         if(copy)
         {
@@ -392,11 +397,7 @@ __global__ void copyshift_down(const bool copy,
 
             // make first column the identity
             if(i == j)
-            {
                 Ap[i + 1] = 0.0;
-                if(j == 0)
-                    Ap[0] = 1.0;
-            }
         }
     }
 }


### PR DESCRIPTION
I think is better if we fix the problem one step deeper: 
The copyshift_ kernels must generate the identity also for 1x1 sizes. 