### PR TITLE
Print version information in rocsolver-bench

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -408,6 +408,8 @@ try
         print_version_info();
 
         rocblas_int device_count = query_device_property();
+        if(device_count <= 0)
+            throw std::runtime_error("No devices found");
         if(device_count <= device_id)
             throw std::invalid_argument("Invalid Device ID");
     }
@@ -439,8 +441,7 @@ try
 
     return 0;
 }
-
-catch(const std::invalid_argument& exp)
+catch(const std::exception& exp)
 {
     fmt::print(stderr, "{}\n", exp.what());
     return -1;


### PR DESCRIPTION
This prints version information when rocsolver-bench is invoked. The version information is not printed when `--perf 1` is added, as that option has a specific output format.

I've also slightly changed the error messages when no devices are found.

Example output:
```
$ ROCR_VISIBLE_DEVICES='' build/release/clients/staging/rocsolver-bench -n 10
rocSOLVER version 3.16.0.2e3d8f64-dirty (with rocBLAS 2.42.0.c98b458c)
Query device error: cannot get device count
No devices found
```